### PR TITLE
Small improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function manifestPlugin(options = {}) {
         entryPoints.forEach((entrypoint) => {
           const name = entrypoint.replace(/\.js$/, '')
           const escapedName = name.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
-          const hashRegex = '[A-Z0-9]{8}' // currently esbuild hashes always look like this
+          const hashRegex = '[A-Z0-9]{8,}'
 
           const jsRegExp = new RegExp(`^${escapedName}(-${hashRegex})?\\.js$`)
           const cssRegExp = new RegExp(`^${escapedName}(-${hashRegex})?\\.css$`)
@@ -71,10 +71,12 @@ function manifestPlugin(options = {}) {
       }
 
       build.onEnd((result) => {
-        const manifest = generateManifest(result.metafile.outputs)
-        const json = serializeManifest(manifest)
+        if (result.metafile) {
+          const manifest = generateManifest(result.metafile.outputs)
+          const json = serializeManifest(manifest)
 
-        fs.writeFileSync(manifestFilePath, json)
+          fs.writeFileSync(manifestFilePath, json)
+        }
       })
     },
   }

--- a/index.js
+++ b/index.js
@@ -36,9 +36,10 @@ function manifestPlugin(options = {}) {
         entryPoints.forEach((entrypoint) => {
           const name = entrypoint.replace(/\.js$/, '')
           const escapedName = name.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
+          const hashRegex = '[A-Z0-9]{8}' // currently esbuild hashes always look like this
 
-          const jsRegExp = new RegExp(`^${escapedName}-[^/]+?\\.js$`)
-          const cssRegExp = new RegExp(`^${escapedName}-[^/]+?\\.css$`)
+          const jsRegExp = new RegExp(`^${escapedName}(-${hashRegex})?\\.js$`)
+          const cssRegExp = new RegExp(`^${escapedName}(-${hashRegex})?\\.css$`)
 
           const jsPath = paths.find(path => jsRegExp.test(path))
           const cssPath = paths.find(path => cssRegExp.test(path))


### PR DESCRIPTION
PR improves two things:

- It emits entrypoints even without a `[hash]` in the output name. This is sensible in development to avoid creating hundreds of bundles over time.
- When the build fails because of an error, the plugin does not produce an additional error because `result.metafile` is missing.